### PR TITLE
Blog implementation

### DIFF
--- a/src/Http/Livewire/Models/ArticleForm.php
+++ b/src/Http/Livewire/Models/ArticleForm.php
@@ -81,9 +81,8 @@ class ArticleForm extends Form
         return Category::all()->pluck('name', 'id');
     }
 
-    public function getPublishableModel() : Publishable
+    public function getPublishableModel(): Publishable
     {
         return $this->article;
     }
-
 }

--- a/src/Models/Article.php
+++ b/src/Models/Article.php
@@ -5,6 +5,7 @@ namespace Astrogoat\Blog\Models;
 use Helix\Fabrick\Icon;
 use Helix\Lego\Models\Contracts\Indexable;
 use Helix\Lego\Models\Contracts\Metafieldable;
+use Helix\Lego\Models\Contracts\Publishable;
 use Helix\Lego\Models\Contracts\Searchable;
 use Helix\Lego\Models\Contracts\Sectionable;
 use Helix\Lego\Models\Model as LegoModel;


### PR DESCRIPTION
For some reason, the publishable contract reference path was removed, just brought it back.